### PR TITLE
Enable CORS

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 import pandas as pd
 
-# Define allowed origins (update with your frontend URL when deployed)
+# Define allowed origins
 origins = [
     "http://localhost:8000",  # React/Vue/Angular running locally
     "http://127.0.0.1:8000",   # Alternative local address
@@ -24,10 +24,10 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,  # Allows specific origins
+    allow_origins=origins,
     allow_credentials=True,
-    allow_methods=["*"],  # Allows all HTTP methods
-    allow_headers=["*"],  # Allows all headers
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 def get_address_data(address: str, city: str, zip: int) -> Dict[str, Any]:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,15 @@
 from typing import Optional, Dict, Any
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 import pandas as pd
+
+# Define allowed origins (update with your frontend URL when deployed)
+origins = [
+    "http://localhost:8000",  # React/Vue/Angular running locally
+    "http://127.0.0.1:8000",   # Alternative local address
+    "http://127.0.0.1:8081",   # Alternative local address
+    "https://www.houstonchronicle.com/",  # Deployed frontend
+]
 
 ## GLOBAL VARS
 id_cols = ['acct', 'owner_2024', 'address_2024', 'city_2024', 'zip_2024', 'tot_mkt_val_2024', 'tot_mkt_val_2023', 'new_construction_val_2024',
@@ -12,6 +21,14 @@ group_cols = ['tot_mkt_val_2023_bin', 'neighborhood_grp_2024', 'neighborhood_grp
               'stories_2024_bin', 'stories_2023_bin']
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,  # Allows specific origins
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all HTTP methods
+    allow_headers=["*"],  # Allows all headers
+)
 
 def get_address_data(address: str, city: str, zip: int) -> Dict[str, Any]:
     """Fetches address-related property data."""


### PR DESCRIPTION
Enable CORS so the API can be accessed from localhost and the live project.

**Details:**
These CORS changes ensure the API can be accessed from other applications running on different domains/ports – so while this repo runs on one domain, these changes ensure it's accessible from the front-end repository, which runs on localhost:8000 and [houstonchronicle.com](http://houstonchronicle.com/).

The full test case would be to set up another local server on port 8000 and making sure that application can successfully make calls to the API while it's running on a another port. You don't need to worry about doing that test full test right now – just a syntax review is fine for this one. (I've tested the full data flow from the front-end [here](https://github.com/sfchronicle/hc-property-taxes-protest-wizard/blob/main/src/pages/index.js#L86).)